### PR TITLE
Bugfix for overflow with large numbers

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,4 @@
+use std::cmp;
 use std::io::{stdin, BufRead};
 use structopt::StructOpt;
 use onig::*;
@@ -13,14 +14,17 @@ struct Opt {
 const SUFFIXES: [&str; 9] = ["", "k", "M", "G", "T", "P", "E", "Z", "Y"];
 
 fn convert(number: &str) -> String {
-    let num: f64 = number.parse().unwrap();
-    let mut exp = (num.log10() / 3.0) as u32;
-    /* Cap exponent to highest suffix. */
-    if exp > 8 {
-        exp = 8;
+    let mut number: f64 = number.parse().unwrap();
+
+    /* Cap exponent to highest suffix (Y = 8). */
+    let exp = cmp::min((number.log10() / 3.0) as u32, 8);
+
+    /* Reduce number by 10^exp to match the suffix. */
+    for _ in 0..exp {
+        number /= 1000.0;
     }
-    let short = num / 1_000u64.pow(exp) as f64;
-    format!("{:.0}{}", short, SUFFIXES[exp as usize])
+
+    format!("{:.0}{}", number, SUFFIXES[exp as usize])
 }
 
 fn main() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -67,5 +67,12 @@ mod tests {
         assert_eq!(convert("9000000000"), "9G");
         assert_eq!(convert("9876543210"), "10G");
         assert_eq!(convert("10476543210"), "10G");
+        assert_eq!(convert("10000000000000"), "10T");
+        assert_eq!(convert("50000000000000000"), "50P");
+        assert_eq!(convert("1000000000000000000"), "1E");
+        assert_eq!(convert("7000000000000000000000"), "7Z");
+        assert_eq!(convert("123400000000000000000000"), "123Z");
+        assert_eq!(convert("99000000000000000000000000"), "99Y");
+        assert_eq!(convert("9876543210000000000000000000"), "9877Y");
     }
 }


### PR DESCRIPTION
Uses iterative division to truncate the number to fit the suffix, rather than raising it to a power of n.

Tests now include really big numbers.

fixes #1
